### PR TITLE
ovr_GetTrackingState: Wait for the poses when requesting the tracking state.

### DIFF
--- a/REV_CAPI.cpp
+++ b/REV_CAPI.cpp
@@ -306,6 +306,9 @@ OVR_PUBLIC_FUNCTION(ovrTrackingState) ovr_GetTrackingState(ovrSession session, d
 {
 	ovrTrackingState state = { 0 };
 
+	// Call WaitGetPoses() to do some cleanup from the previous frame.
+	session->compositor->WaitGetPoses(session->poses, vr::k_unMaxTrackedDeviceCount, session->gamePoses, vr::k_unMaxTrackedDeviceCount);
+
 	// Gain focus for the compositor
 	float time = (float)ovr_GetTimeInSeconds();
 
@@ -725,9 +728,6 @@ OVR_PUBLIC_FUNCTION(ovrResult) ovr_SubmitFrame(ovrSession session, long long fra
 	ovrLayerHeader const * const * layerPtrList, unsigned int layerCount)
 {
 	// TODO: Implement scaling through ApplyTransform().
-
-	// Call WaitGetPoses() to do some cleanup from the previous frame.
-	session->compositor->WaitGetPoses(session->poses, vr::k_unMaxTrackedDeviceCount, session->gamePoses, vr::k_unMaxTrackedDeviceCount);
 
 	if (layerCount == 0)
 		return ovrError_InvalidParameter;


### PR DESCRIPTION
It makes a lot more sense to wait for the poses here and it also fixes Project Cars. It is also where I originally intended to make this call.

Unfortunately this makes Lucky's Tale crash, so I have to find a solution for that before merging this into master.