### PR TITLE
Trigger and Grip Button Swapped Mode

### DIFF
--- a/Revive/InputManager.cpp
+++ b/Revive/InputManager.cpp
@@ -418,10 +418,20 @@ bool InputManager::OculusTouch::GetInputState(ovrSession session, ovrInputState*
 
 	// When we release the grip we need to keep it just a little bit pressed, because games like Toybox
 	// can't handle a sudden jump to absolute zero.
-	if (m_Gripped)
-		inputState->HandTrigger[hand] = 1.0f;
+	if (session->ToggleGrip == revGrip_Normal)
+	{
+		if (m_Gripped)
+			inputState->IndexTrigger[hand] = 1.0f;
+		else
+			inputState->IndexTrigger[hand] = 0.1f;
+	}
 	else
-		inputState->HandTrigger[hand] = 0.1f;
+	{
+		if (m_Gripped)
+			inputState->HandTrigger[hand] = 1.0f;
+		else
+			inputState->HandTrigger[hand] = 0.1f;
+	}
 
 	// Convert the axes
 	for (int j = 0; j < vr::k_unControllerStateAxisCount; j++)
@@ -537,10 +547,18 @@ bool InputManager::OculusTouch::GetInputState(ovrSession session, ovrInputState*
 				touches |= (hand == ovrHand_Left) ? ovrTouch_LIndexTrigger : ovrTouch_RIndexTrigger;
 			else if (m_Gripped)
 				touches |= (hand == ovrHand_Left) ? ovrTouch_LIndexPointing : ovrTouch_RIndexPointing;
-
-			inputState->IndexTrigger[hand] = axis.x;
+			if (session->ToggleGrip == revGrip_Normal)
+			{
+				inputState->HandTrigger[hand] = axis.x;
+			}
+			else
+			{
+				inputState->IndexTrigger[hand] = axis.x;
+			}
 		}
 	}
+
+
 
 	// We don't apply deadzones yet on triggers and grips
 	inputState->IndexTriggerNoDeadzone[hand] = inputState->IndexTrigger[hand];

--- a/Revive/InputManager.cpp
+++ b/Revive/InputManager.cpp
@@ -418,7 +418,7 @@ bool InputManager::OculusTouch::GetInputState(ovrSession session, ovrInputState*
 
 	// When we release the grip we need to keep it just a little bit pressed, because games like Toybox
 	// can't handle a sudden jump to absolute zero.
-	if (session->ToggleGrip == revGrip_Normal)
+	if (session->ToggleGrip == revGrip_Trigger)
 	{
 		if (m_Gripped)
 			inputState->IndexTrigger[hand] = 1.0f;
@@ -543,7 +543,7 @@ bool InputManager::OculusTouch::GetInputState(ovrSession session, ovrInputState*
 		}
 		else if (type == vr::k_eControllerAxis_Trigger)
 		{
-			if (session->ToggleGrip == revGrip_Normal)
+			if (session->ToggleGrip == revGrip_Trigger)
 			{
 				if (m_Gripped)
 					touches |= (hand == ovrHand_Left) ? ovrTouch_LIndexTrigger : ovrTouch_RIndexTrigger;

--- a/Revive/InputManager.cpp
+++ b/Revive/InputManager.cpp
@@ -543,17 +543,21 @@ bool InputManager::OculusTouch::GetInputState(ovrSession session, ovrInputState*
 		}
 		else if (type == vr::k_eControllerAxis_Trigger)
 		{
-			if (state.ulButtonTouched & vr::ButtonMaskFromId(button))
-				touches |= (hand == ovrHand_Left) ? ovrTouch_LIndexTrigger : ovrTouch_RIndexTrigger;
-			else if (m_Gripped)
-				touches |= (hand == ovrHand_Left) ? ovrTouch_LIndexPointing : ovrTouch_RIndexPointing;
 			if (session->ToggleGrip == revGrip_Normal)
 			{
+				if (m_Gripped)
+					touches |= (hand == ovrHand_Left) ? ovrTouch_LIndexTrigger : ovrTouch_RIndexTrigger;
+				else if (state.ulButtonTouched & vr::ButtonMaskFromId(button))
+					touches |= (hand == ovrHand_Left) ? ovrTouch_LIndexPointing : ovrTouch_RIndexPointing;
 				inputState->HandTrigger[hand] = axis.x;
 			}
 			else
 			{
 				inputState->IndexTrigger[hand] = axis.x;
+				if (state.ulButtonTouched & vr::ButtonMaskFromId(button))
+					touches |= (hand == ovrHand_Left) ? ovrTouch_LIndexTrigger : ovrTouch_RIndexTrigger;
+				else if (m_Gripped)
+					touches |= (hand == ovrHand_Left) ? ovrTouch_LIndexPointing : ovrTouch_RIndexPointing;
 			}
 		}
 	}

--- a/Revive/Settings.h
+++ b/Revive/Settings.h
@@ -5,6 +5,7 @@ enum revGripType
 	revGrip_Normal = 0,
 	revGrip_Toggle = 1,
 	revGrip_Hybrid = 2,
+	revGrip_Trigger = 3,
 };
 
 #define REV_SETTINGS_SECTION				"revive"


### PR DESCRIPTION
In some games like Echo Arena, the grip button must be used very often, but the Toggle and Hybrid modes don't work well. I added a new grip mode ("revGrip_Trigger") that swaps the grip and trigger buttons. In Echo Arena the trigger isn't used nearly as often as the grip, so this makes the game much more comfortable to play.