### PR TITLE
Use TriggerAsGrip property to toggle swapped mode

### DIFF
--- a/Revive/InputManager.cpp
+++ b/Revive/InputManager.cpp
@@ -542,6 +542,9 @@ bool InputManager::OculusTouch::GetInputState(ovrSession session, ovrInputState*
 		}
 	}
 
+	if (session->TriggerAsGrip)
+		std::swap(inputState->IndexTrigger[hand], inputState->HandTrigger[hand]);
+
 	// We don't apply deadzones yet on triggers and grips
 	inputState->IndexTriggerNoDeadzone[hand] = inputState->IndexTrigger[hand];
 	inputState->HandTriggerNoDeadzone[hand] = inputState->HandTrigger[hand];

--- a/Revive/Session.cpp
+++ b/Revive/Session.cpp
@@ -37,6 +37,7 @@ void ovrHmdStruct::LoadSettings()
 	Deadzone = ovr_GetFloat(this, REV_KEY_THUMB_DEADZONE, REV_DEFAULT_THUMB_DEADZONE);
 	Sensitivity = ovr_GetFloat(this, REV_KEY_THUMB_SENSITIVITY, REV_DEFAULT_THUMB_SENSITIVITY);
 	ToggleGrip = (revGripType)ovr_GetInt(this, REV_KEY_TOGGLE_GRIP, REV_DEFAULT_TOGGLE_GRIP);
+	TriggerAsGrip = ovr_GetBool(this, REV_KEY_TRIGGER_GRIP, REV_DEFAULT_TRIGGER_GRIP);
 	ToggleDelay = ovr_GetFloat(this, REV_KEY_TOGGLE_DELAY, REV_DEFAULT_TOGGLE_DELAY);
 	IgnoreActivity = !!ovr_GetBool(this, REV_KEY_IGNORE_ACTIVITYLEVEL, REV_DEFAULT_IGNORE_ACTIVITYLEVEL);
 

--- a/Revive/Session.h
+++ b/Revive/Session.h
@@ -35,6 +35,7 @@ struct ovrHmdStruct
 	float Deadzone;
 	float Sensitivity;
 	revGripType ToggleGrip;
+	bool TriggerAsGrip;
 	float ToggleDelay;
 	bool IgnoreActivity;
 	ovrVector3f RotationOffset, PositionOffset;

--- a/Revive/Settings.h
+++ b/Revive/Settings.h
@@ -25,6 +25,9 @@ enum revGripType
 #define REV_KEY_TOGGLE_GRIP					"ToggleGrip"
 #define REV_DEFAULT_TOGGLE_GRIP				revGrip_Normal
 
+#define REV_KEY_TRIGGER_GRIP				"TriggerAsGrip"
+#define REV_DEFAULT_TRIGGER_GRIP			false
+
 #define REV_KEY_TOGGLE_DELAY				"ToggleDelay"
 #define REV_DEFAULT_TOGGLE_DELAY			0.5f
 


### PR DESCRIPTION
In some games like Echo Arena, the grip button must be used very often, but the Toggle and Hybrid modes don't work well. The TriggerAsGrip property will swap the trigger and grip buttons. 