### PR TITLE
Reducing far frustum value as large value seems to break CocoVR

### DIFF
--- a/Revive/SessionDetails.cpp
+++ b/Revive/SessionDetails.cpp
@@ -144,7 +144,7 @@ void SessionDetails::UpdateTrackerDesc()
 			desc.FrustumVFovInRadians = OVR::DegreeToRad(180.0);
 			// Get the tracking frustum.
 			desc.FrustumNearZInMeters = 1;
-			desc.FrustumFarZInMeters = 20;
+			desc.FrustumFarZInMeters = 10;
 		}
 		else 
 		{


### PR DESCRIPTION
For some reason, large far frustum was breaking CocoVR. Reducing it to 10 meters fixes the problem.