### PR TITLE
Update CompositorBase.cpp

### DIFF
--- a/Revive/CompositorBase.cpp
+++ b/Revive/CompositorBase.cpp
@@ -160,7 +160,7 @@ ovrResult CompositorBase::EndFrame(ovrSession session, ovrLayerHeader const * co
 			if (layer->Header.Flags & ovrLayerFlag_HeadLocked)
 				vr::VROverlay()->SetOverlayTransformTrackedDeviceRelative(overlay, vr::k_unTrackedDeviceIndex_Hmd, &transform);
 			else
-				vr::VROverlay()->SetOverlayTransformAbsolute(overlay, vr::VRCompositor()->GetTrackingSpace(), &transform);
+				vr::VROverlay()->SetOverlayTransformAbsolute(overlay, session->TrackingOrigin, &transform);
 
 			// Set the texture and show the overlay.
 			vr::VRTextureBounds_t bounds = ViewportToTextureBounds(layer->Viewport, layer->ColorTexture, layer->Header.Flags);


### PR DESCRIPTION
Since `vr::VRCompositor()->SetTrackingSpace()` is never called in any other parts of the code, I believe it's better to use the stored TrackingOrigin for the session here. Otherwise all not-headlocked overlays will default to `TrackingUniverseStanding`, which means that they will end up in the floor instead of in front of your eyes (at least that's what happens with my NOLF2 mod)