### PR TITLE
misc revivexr fixes

### DIFF
--- a/ReviveInjector/inject.cpp
+++ b/ReviveInjector/inject.cpp
@@ -149,7 +149,7 @@ bool InjectOpenVR(HANDLE hProcess, HANDLE hThread, bool xr)
 	char dllPath[MAX_PATH];
 	if (xr)
 	{
-		GetAbsolutePath(dllPath, MAX_PATH, "openxr_loader-0_90.dll");
+		GetAbsolutePath(dllPath, MAX_PATH, "openxr_loader-1_0.dll");
 	}
 	else
 	{

--- a/ReviveInjector/main.cpp
+++ b/ReviveInjector/main.cpp
@@ -132,7 +132,7 @@ int wmain(int argc, wchar_t *argv[]) {
 		{
 			return OpenProcessAndInject(argv[++i], xr);
 		}
-		if (wcscmp(argv[i], L"/app") == 0)
+		else if (wcscmp(argv[i], L"/app") == 0)
 		{
 			appKey = "application.generated.revive.app." + std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t>().to_bytes(argv[++i]);
 		}

--- a/ReviveXR/InputManager.cpp
+++ b/ReviveXR/InputManager.cpp
@@ -435,17 +435,16 @@ XrPath InputManager::OculusTouch::GetSuggestedBindings(std::vector<XrActionSugge
 
 	for (int i = 0; i < ovrHand_Count; i++)
 	{
+		ADD_BINDING(m_Thumbstick, prefixes[i] + "/input/thumbstick");
 		ADD_BINDING(m_Button_Thumb, prefixes[i] + "/input/thumbstick/click");
-
-		ADD_BINDING(m_Touch_Thumb, prefixes[i] + "/input/thumbstick");
+		ADD_BINDING(m_Touch_Thumb, prefixes[i] + "/input/thumbstick/touch");
 		ADD_BINDING(m_Touch_ThumbRest, prefixes[i] + "/input/thumbrest/touch");
 		ADD_BINDING(m_Touch_IndexTrigger, prefixes[i] + "/input/trigger/touch");
 
 		ADD_BINDING(m_IndexTrigger, prefixes[i] + "/input/trigger/value");
-		ADD_BINDING(m_HandTrigger, prefixes[i] + "/input/grip/value");
-		ADD_BINDING(m_Thumbstick, prefixes[i] + "/input/thumbstick");
+		ADD_BINDING(m_HandTrigger, prefixes[i] + "/input/squeeze/value");
 
-		ADD_BINDING(m_Pose, prefixes[i] + "/input/pointer/pose");
+		ADD_BINDING(m_Pose, prefixes[i] + "/input/aim/pose");
 		ADD_BINDING(m_Vibration, prefixes[i] + "/output/haptic");
 	}
 

--- a/ReviveXR/REV_CAPI.cpp
+++ b/ReviveXR/REV_CAPI.cpp
@@ -184,9 +184,15 @@ OVR_PUBLIC_FUNCTION(ovrResult) ovr_Create(ovrSession* pSession, ovrGraphicsLuid*
 	// Initialize the opaque pointer with our own OpenVR-specific struct
 	g_Sessions.emplace_back();
 
+	// Initialize session members
 	ovrSession session = &g_Sessions.back();
 	session->Instance = g_Instance;
 	session->TrackingSpace = XR_REFERENCE_SPACE_TYPE_LOCAL;
+	session->SystemProperties = XR_TYPE(SYSTEM_PROPERTIES);
+	for (int i = 0; i < ovrEye_Count; i++) {
+		session->ViewConfigs[i] = XR_TYPE(VIEW_CONFIGURATION_VIEW);
+		session->DefaultEyeViews[i] = XR_TYPE(VIEW);
+	}
 
 	// Initialize input
 	session->Input.reset(new InputManager(session->Instance));
@@ -899,6 +905,7 @@ OVR_PUBLIC_FUNCTION(ovrResult) ovr_WaitToBeginFrame(ovrSession session, long lon
 		return ovrError_InvalidSession;
 
 	XrFrameWaitInfo waitInfo = XR_TYPE(FRAME_WAIT_INFO);
+	session->FrameState = XR_TYPE(FRAME_STATE);
 	CHK_XR(xrWaitFrame(session->Session, &waitInfo, &session->FrameState));
 	return ovrSuccess;
 }

--- a/ReviveXR/REV_CAPI.cpp
+++ b/ReviveXR/REV_CAPI.cpp
@@ -287,8 +287,9 @@ OVR_PUBLIC_FUNCTION(void) ovr_Destroy(ovrSession session)
 	XrSession handle = session->Session;
 	if (handle)
 	{
-		XrResult rs = xrEndSession(handle);
-		assert(XR_SUCCEEDED(rs));
+		xrRequestExitSession(session->Session);
+		while (!XR_SUCCEEDED(xrEndSession(handle)))
+			std::this_thread::sleep_for(std::chrono::milliseconds(100));
 	}
 
 	if (session->HookedFunction)

--- a/ReviveXR/REV_CAPI.cpp
+++ b/ReviveXR/REV_CAPI.cpp
@@ -264,11 +264,15 @@ OVR_PUBLIC_FUNCTION(ovrResult) ovr_Create(ovrSession* pSession, ovrGraphicsLuid*
 		XrViewLocateInfo locateInfo = XR_TYPE(VIEW_LOCATE_INFO);
 		XrViewState viewState = XR_TYPE(VIEW_STATE);
 		locateInfo.space = viewSpace;
+		locateInfo.viewConfigurationType = beginInfo.primaryViewConfigurationType;
+		locateInfo.displayTime = 1337;
 		XrResult rs = xrLocateViews(fakeSession, &locateInfo, &viewState, ovrEye_Count, &numViews, session->DefaultEyeViews);
 		assert(XR_SUCCEEDED(rs));
 		assert(numViews == ovrEye_Count);
 
-		CHK_XR(xrEndSession(fakeSession));
+		xrRequestExitSession(fakeSession);
+		while (!XR_SUCCEEDED(xrEndSession(fakeSession)))
+			std::this_thread::sleep_for(std::chrono::milliseconds(100));
 		CHK_XR(xrDestroySession(fakeSession));
 	}
 


### PR DESCRIPTION
* Fix arg parsing issue in ReviveInjector
* Change openxr loader dll to 1.0 in ReviveInjector
* Initialize struct members where required by openxr
* Gracefully handle openxr session shutdown
* Fix malformed input subpaths for Oculus Touch