### PR TITLE
Multi libs

### DIFF
--- a/ReviveInjector/main.cpp
+++ b/ReviveInjector/main.cpp
@@ -118,6 +118,15 @@ int wmain(int argc, wchar_t *argv[]) {
 	bool apc = false;
 	std::string appKey;
 	WCHAR path[MAX_PATH] = { 0 };
+	//3 new variables: not very good
+	WCHAR endPath[MAX_PATH] = { 0 };
+	WCHAR basePath[MAX_PATH] = { 0 };
+	WCHAR library[MAX_PATH] = { 0 };
+	// TODO: cleaning
+	//for (int i = 1; i < argc; i++)
+	//{
+	//	LOG("values %d %ls\n",i, argv[i]);
+	//}
 	for (int i = 1; i < argc; i++)
 	{
 		if (wcscmp(argv[i], L"/xr") == 0)
@@ -144,18 +153,33 @@ int wmain(int argc, wchar_t *argv[]) {
 		}
 		else if (wcscmp(argv[i], L"/library") == 0)
 		{
-			if (!GetDefaultLibraryPath(path, MAX_PATH))
-				return -1;
-			wnsprintf(path, MAX_PATH, L"%s\\%s ", path, argv[++i]);
+			wcsncat(library, argv[++i], MAX_PATH);
+		}
+		//force path if not default Oculus folder
+		else if (wcscmp(argv[i], L"/baseLib") == 0)
+		{
+			wcsncat(basePath, argv[++i], MAX_PATH);
 		}
 		else
 		{
 			// Concatenate all other arguments
-			wcsncat(path, argv[i], MAX_PATH);
-			wcsncat(path, L" ", MAX_PATH);
+			wcsncat(endPath, argv[i], MAX_PATH);
+			wcsncat(endPath, L" ", MAX_PATH);
 		}
 	}
-
+	
+	if (wcslen(basePath) != 0) {
+		wnsprintf(path, MAX_PATH, L"%s\\%s ", basePath, library);
+	}
+	else {
+		if (!GetDefaultLibraryPath(path, MAX_PATH))
+			return -1;
+		wnsprintf(path, MAX_PATH, L"%s\\%s ", path, library);
+	}
+	wcsncat(path, endPath, MAX_PATH);
+	
+	LOG("Path for injector is: %ls\n", path);
+	
 	uint32_t processId = CreateProcessAndInject(path, xr, apc);
 	if (!appKey.empty())
 	{

--- a/ReviveInjector/main.cpp
+++ b/ReviveInjector/main.cpp
@@ -119,9 +119,10 @@ int wmain(int argc, wchar_t *argv[]) {
 	std::string appKey;
 	WCHAR path[MAX_PATH] = { 0 };
 	//3 new variables: not very good
-	WCHAR endPath[MAX_PATH] = { 0 };
-	WCHAR basePath[MAX_PATH] = { 0 };
+	WCHAR otherArgs[MAX_PATH] = { 0 };
+	WCHAR libraryBase[MAX_PATH] = { 0 };
 	WCHAR library[MAX_PATH] = { 0 };
+	WCHAR support[MAX_PATH] = { 0 };
 	// TODO: cleaning
 	//for (int i = 1; i < argc; i++)
 	//{
@@ -147,9 +148,7 @@ int wmain(int argc, wchar_t *argv[]) {
 		}
 		else if (wcscmp(argv[i], L"/base") == 0)
 		{
-			if (!GetOculusBasePath(path, MAX_PATH))
-				return -1;
-			wnsprintf(path, MAX_PATH, L"%s\\%s ", path, argv[++i]);
+			wcsncat(support, argv[++i], MAX_PATH);
 		}
 		else if (wcscmp(argv[i], L"/library") == 0)
 		{
@@ -158,25 +157,33 @@ int wmain(int argc, wchar_t *argv[]) {
 		//force path if not default Oculus folder
 		else if (wcscmp(argv[i], L"/baseLib") == 0)
 		{
-			wcsncat(basePath, argv[++i], MAX_PATH);
+			wcsncat(libraryBase, argv[++i], MAX_PATH);
 		}
 		else
 		{
 			// Concatenate all other arguments
-			wcsncat(endPath, argv[i], MAX_PATH);
-			wcsncat(endPath, L" ", MAX_PATH);
+			wcsncat(otherArgs, argv[i], MAX_PATH);
+			wcsncat(otherArgs, L" ", MAX_PATH);
 		}
 	}
-	
-	if (wcslen(basePath) != 0) {
-		wnsprintf(path, MAX_PATH, L"%s\\%s ", basePath, library);
+
+	//path reconstruction
+
+	//support app ?
+	if (wcslen(support) != 0) {
+		if (!GetOculusBasePath(path, MAX_PATH))
+			return -1;
+		wnsprintf(path, MAX_PATH, L"%s\\%s ", path, support);
+	}
+	else if (wcslen(libraryBase) != 0) {
+		wnsprintf(path, MAX_PATH, L"%s\\%s ", libraryBase, library);
 	}
 	else {
 		if (!GetDefaultLibraryPath(path, MAX_PATH))
 			return -1;
 		wnsprintf(path, MAX_PATH, L"%s\\%s ", path, library);
 	}
-	wcsncat(path, endPath, MAX_PATH);
+	wcsncat(path, otherArgs, MAX_PATH);
 	
 	LOG("Path for injector is: %ls\n", path);
 	

--- a/ReviveOverlay/Oculus.js
+++ b/ReviveOverlay/Oculus.js
@@ -4,6 +4,15 @@ function decodeHtml(str) {
   });
 };
 
+function createObjects() {
+    //create folderListModels for each folder
+    for (var index in Revive.LibrariesURL){
+        Qt.createQmlObject('import QtQuick 2.4;import Qt.labs.folderlistmodel 2.1;import "Oculus.js" as Oculus;FolderListModel {id: manifestsModelindex;folder: Revive.LibrariesURL[index] + \'Manifests/\';nameFilters: ["*.json"];showDirs: false;onCountChanged: {coverModel.remove(4, coverModel.count - 4);for (var i = 0; i < manifestsModelindex.count; i++){Oculus.loadManifest(manifestsModelindex.get(i, "fileURL"), Revive.LibrariesURL[index]);}}}'.replace(/index/g, index),
+    mainWindow, "dynamicFolderObjects");
+    }
+}
+
+
 function generateManifest(manifest, basePath) {
     console.log("Generating manifest for " + manifest["canonicalName"]);
     var launch = manifest["launchFile"];

--- a/ReviveOverlay/Oculus.js
+++ b/ReviveOverlay/Oculus.js
@@ -88,13 +88,11 @@ function verifyAppManifest(appKey) {
     // Load the smaller mini file since we only want to verify whether it exists.
 	 var appToRemove = Revive.LibrariesURL.length;
     for (var index in Revive.LibrariesURL) {
-        console.log("parsing lib " + Revive.LibrariesURL[index]);
         var manifestURL = Revive.LibrariesURL[index] + 'Manifests/' + appKey + '.json.mini';
         var xhr = new XMLHttpRequest;
         //remove async access, needed to synchronize appToRemove list
         xhr.open('GET', manifestURL, false);
         xhr.send(null);
-        console.log("xhr status " + appKey + " " + xhr.status);
         if (xhr.status != 200) {
             if (!Revive.isApplicationInstalled(appKey)) {
                 appToRemove--;

--- a/ReviveOverlay/Overlay.qml
+++ b/ReviveOverlay/Overlay.qml
@@ -9,43 +9,10 @@ Rectangle {
     width: 1920
     height: 1080
     color: "#183755"
+	id: mainWindow
 
-	// manifestsModel, manifestsModel2, manifestsModel3: libraries locations
-    FolderListModel {
-        id: manifestsModel
-        folder: Revive.LibrariesURL[0] + 'Manifests/'
-        nameFilters: ["*.json"]
-        showDirs: false
-        onCountChanged: {
-            coverModel.remove(4, coverModel.count - 4);		
-            for (var i = 0; i < manifestsModel.count; i++)
-                Oculus.loadManifest(manifestsModel.get(i, "fileURL"), Revive.LibrariesURL[0]);
-        }
-    }
-
-	FolderListModel {
-    id: manifestsModel2
-    folder: Revive.LibrariesURL[1] + 'Manifests/'
-    nameFilters: ["*.json"]
-    showDirs: false
-    onCountChanged: {
-        coverModel.remove(4, coverModel.count - 4);
-        for (var i = 0; i < manifestsModel2.count; i++)
-            Oculus.loadManifest(manifestsModel2.get(i, "fileURL"), Revive.LibrariesURL[1]);
-        }
-    }
-
-	FolderListModel {
-    id: manifestsModel3
-    folder: Revive.LibrariesURL[2] + 'Manifests/'
-    nameFilters: ["*.json"]
-    showDirs: false
-    onCountChanged: {
-        coverModel.remove(4, coverModel.count - 4);
-        for (var i = 0; i < manifestsModel3.count; i++)
-            Oculus.loadManifest(manifestsModel3.get(i, "fileURL"), Revive.LibrariesURL[2]);
-        }
-    }
+	Component.onCompleted: Oculus.createObjects();
+   
     FolderListModel {
         id: assetsModel
         folder: Revive.BaseURL + 'CoreData/Manifests/'

--- a/ReviveOverlay/Overlay.qml
+++ b/ReviveOverlay/Overlay.qml
@@ -10,18 +10,42 @@ Rectangle {
     height: 1080
     color: "#183755"
 
+	// manifestsModel, manifestsModel2, manifestsModel3: libraries locations
     FolderListModel {
         id: manifestsModel
-        folder: Revive.LibraryURL + 'Manifests/'
+        folder: Revive.LibrariesURL[0] + 'Manifests/'
         nameFilters: ["*.json"]
         showDirs: false
         onCountChanged: {
-            coverModel.remove(4, coverModel.count - 4);
+            coverModel.remove(4, coverModel.count - 4);		
             for (var i = 0; i < manifestsModel.count; i++)
-                Oculus.loadManifest(manifestsModel.get(i, "fileURL"));
+                Oculus.loadManifest(manifestsModel.get(i, "fileURL"), Revive.LibrariesURL[0]);
         }
     }
 
+	FolderListModel {
+    id: manifestsModel2
+    folder: Revive.LibrariesURL[1] + 'Manifests/'
+    nameFilters: ["*.json"]
+    showDirs: false
+    onCountChanged: {
+        coverModel.remove(4, coverModel.count - 4);
+        for (var i = 0; i < manifestsModel2.count; i++)
+            Oculus.loadManifest(manifestsModel2.get(i, "fileURL"), Revive.LibrariesURL[1]);
+        }
+    }
+
+	FolderListModel {
+    id: manifestsModel3
+    folder: Revive.LibrariesURL[2] + 'Manifests/'
+    nameFilters: ["*.json"]
+    showDirs: false
+    onCountChanged: {
+        coverModel.remove(4, coverModel.count - 4);
+        for (var i = 0; i < manifestsModel3.count; i++)
+            Oculus.loadManifest(manifestsModel3.get(i, "fileURL"), Revive.LibrariesURL[2]);
+        }
+    }
     FolderListModel {
         id: assetsModel
         folder: Revive.BaseURL + 'CoreData/Manifests/'
@@ -34,7 +58,10 @@ Rectangle {
             {
                 var key = assetsModel.get(i, "fileName");
                 console.log("Found assets bundle " + key);
-                Oculus.verifyAppManifest(key.substring(0, key.indexOf("_assets")));
+				var appManifest = key.substring(0, key.indexOf("_assets"));
+				//verify only assets files
+				if (appManifest.length !=0)
+					Oculus.verifyAppManifest(appManifest);
             }
         }
     }

--- a/ReviveOverlay/revivemanifestcontroller.cpp
+++ b/ReviveOverlay/revivemanifestcontroller.cpp
@@ -74,39 +74,13 @@ void QueryKey(HKEY hKey, QStringList &path_array)
 {
 	TCHAR    achKey[MAX_KEY_LENGTH];   // buffer for subkey name
 	DWORD    cbName;                   // size of name string 
-	TCHAR    achClass[MAX_PATH] = TEXT("");  // buffer for class name 
-	DWORD    cchClassName = MAX_PATH;  // size of class string 
 	DWORD    cSubKeys = 0;               // number of subkeys 
-	DWORD    cbMaxSubKey;              // longest subkey size 
-	DWORD    cchMaxClass;              // longest class string 
-	DWORD    cValues;              // number of values for key 
-	DWORD    cchMaxValue;          // longest value name 
-	DWORD    cbMaxValueData;       // longest value data 
-	DWORD    cbSecurityDescriptor; // size of security descriptor 
-	FILETIME ftLastWriteTime;      // last write time 
-
 	DWORD i, retCode;
 
-	TCHAR  achValue[MAX_VALUE_NAME];
-	DWORD cchValue = MAX_VALUE_NAME;
-
 	// Get the class name and the value count. 
-	retCode = RegQueryInfoKey(
-		hKey,                    // key handle 
-		achClass,                // buffer for class name 
-		&cchClassName,           // size of class string 
-		NULL,                    // reserved 
-		&cSubKeys,               // number of subkeys 
-		&cbMaxSubKey,            // longest subkey size 
-		&cchMaxClass,            // longest class string 
-		&cValues,                // number of values for this key 
-		&cchMaxValue,            // longest value name 
-		&cbMaxValueData,         // longest value data 
-		&cbSecurityDescriptor,   // security descriptor 
-		&ftLastWriteTime);       // last write time 
+	retCode = RegQueryInfoKey(hKey, NULL, NULL, NULL, /* number of subkeys*/ &cSubKeys, NULL, NULL, NULL, NULL, NULL, NULL, NULL); 
 
 	// Enumerate the subkeys, until RegEnumKeyEx fails.
-
 	if (cSubKeys)
 	{
 		WCHAR* paths = new WCHAR[cSubKeys];
@@ -120,7 +94,7 @@ void QueryKey(HKEY hKey, QStringList &path_array)
 				NULL,
 				NULL,
 				NULL,
-				&ftLastWriteTime);
+				NULL);
 			if (retCode == ERROR_SUCCESS)
 			{
 				wprintf(TEXT("(%d) %s\n"), i + 1, achKey);

--- a/ReviveOverlay/revivemanifestcontroller.h
+++ b/ReviveOverlay/revivemanifestcontroller.h
@@ -11,10 +11,11 @@
 class CReviveManifestController : public QObject
 {
 	Q_OBJECT
-	typedef QObject BaseClass;
+	typedef QObject BaseClass; 
 
 	Q_PROPERTY(bool LibraryFound READ IsLibraryFound NOTIFY LibraryChanged)
 	Q_PROPERTY(QString LibraryURL READ GetLibraryURL NOTIFY LibraryChanged)
+	Q_PROPERTY(QStringList LibrariesURL READ GetLibrariesURL NOTIFY LibraryChanged)
 	Q_PROPERTY(QString LibraryPath READ GetLibraryPath NOTIFY LibraryChanged)
 	Q_PROPERTY(QString BaseURL READ GetBaseURL NOTIFY BaseChanged)
 	Q_PROPERTY(QString BasePath READ GetBasePath NOTIFY BaseChanged)
@@ -36,6 +37,7 @@ public:
 	QString GetLibraryPath() { return m_strLibraryPath; }
 	QString GetBaseURL() { return m_strBaseURL; }
 	QString GetBasePath() { return m_strBasePath; }
+	QStringList GetLibrariesURL() { return m_lstLibrariesURL; }
 
 	Q_INVOKABLE bool addManifest(const QString &canonicalName, const QString &manifest);
 	Q_INVOKABLE bool removeManifest(const QString &canonicalName);
@@ -50,6 +52,7 @@ private:
 	bool LoadDocument();
 	bool SaveDocument();
 	bool GetDefaultLibraryPath(wchar_t* path, uint32_t length);
+	bool GetLibrariesPath(QStringList & path_array, uint32_t length);
 	bool AddApplicationManifest(QFile& file);
 	bool LaunchSupportApp(const QString& appKey);
 	bool LaunchInjector(const QString& args);
@@ -66,6 +69,7 @@ private:
 	QString m_strLibraryPath;
 	QString m_strBaseURL;
 	QString m_strBasePath;
+	QStringList m_lstLibrariesURL;						   
 	bool m_OpenXREnabled;
 };
 


### PR DESCRIPTION
So, these are my changes made on overlay and injector in order to manage more than one oculus app folder (app #928 enhancement)

Briefly: folders are retrieved from windows registry in ReviveManifestController and parsed in qml and js file, like before, but with an iteration.
For each app, a new parameter "baseLib" is added to revive manifest file and is used by main.cpp class of reviveInjector.

That's all.

