### PR TITLE
Fix Detours interface in Revive and OpenVR DLLs

### DIFF
--- a/Externals/openvr_api.def
+++ b/Externals/openvr_api.def
@@ -1,0 +1,3 @@
+LIBRARY
+EXPORTS
+    DetourFinishHelperProcess   @1

--- a/Externals/openvr_api.vcxproj
+++ b/Externals/openvr_api.vcxproj
@@ -38,6 +38,14 @@
     <ClInclude Include="openvr\src\vrcommon\strtools_public.h" />
     <ClInclude Include="openvr\src\vrcommon\vrpathregistry_public.h" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="openvr_api.def" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="Detours.vcxproj">
+      <Project>{8776bf45-11e0-4e82-9480-c9316cab5c42}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{8940FE26-E0D4-4977-8A24-AB26AE687432}</ProjectGuid>
@@ -127,6 +135,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ModuleDefinitionFile>openvr_api.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -142,6 +151,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ModuleDefinitionFile>openvr_api.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -161,6 +171,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ModuleDefinitionFile>openvr_api.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -180,6 +191,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ModuleDefinitionFile>openvr_api.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Externals/openvr_api.vcxproj.filters
+++ b/Externals/openvr_api.vcxproj.filters
@@ -72,4 +72,9 @@
       <Filter>Header Files\vrcommon</Filter>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="openvr_api.def">
+      <Filter>Source Files</Filter>
+    </None>
+  </ItemGroup>
 </Project>

--- a/Revive/Revive.def
+++ b/Revive/Revive.def
@@ -1,0 +1,3 @@
+LIBRARY
+EXPORTS
+    DetourFinishHelperProcess   @1

--- a/Revive/Revive.vcxproj
+++ b/Revive/Revive.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -117,6 +117,7 @@
       <AdditionalDependencies>Ws2_32.lib;opengl32.lib;dxgi.lib;dxguid.lib;dsound.lib;Winmm.lib;Shlwapi.lib;glfw3.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ImportLibrary>$(IntDir)$(TargetName).lib</ImportLibrary>
       <IgnoreSpecificDefaultLibraries>libcmt.lib</IgnoreSpecificDefaultLibraries>
+      <ModuleDefinitionFile>Revive.def</ModuleDefinitionFile>
     </Link>
     <FxCompile>
       <HeaderFileOutput>%(Filename).hlsl.h</HeaderFileOutput>
@@ -144,6 +145,7 @@
       <AdditionalDependencies>Ws2_32.lib;opengl32.lib;dxgi.lib;dxguid.lib;dsound.lib;Winmm.lib;Shlwapi.lib;glfw3.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ImportLibrary>$(IntDir)$(TargetName).lib</ImportLibrary>
       <IgnoreSpecificDefaultLibraries>libcmt.lib</IgnoreSpecificDefaultLibraries>
+      <ModuleDefinitionFile>Revive.def</ModuleDefinitionFile>
     </Link>
     <FxCompile>
       <HeaderFileOutput>%(Filename).hlsl.h</HeaderFileOutput>
@@ -174,6 +176,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>Ws2_32.lib;opengl32.lib;dxgi.lib;dxguid.lib;dsound.lib;Winmm.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ImportLibrary>$(IntDir)$(TargetName).lib</ImportLibrary>
+      <ModuleDefinitionFile>Revive.def</ModuleDefinitionFile>
     </Link>
     <FxCompile>
       <HeaderFileOutput>%(Filename).hlsl.h</HeaderFileOutput>
@@ -204,6 +207,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>Ws2_32.lib;opengl32.lib;dxgi.lib;dxguid.lib;dsound.lib;Winmm.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ImportLibrary>$(IntDir)$(TargetName).lib</ImportLibrary>
+      <ModuleDefinitionFile>Revive.def</ModuleDefinitionFile>
     </Link>
     <FxCompile>
       <HeaderFileOutput>%(Filename).hlsl.h</HeaderFileOutput>
@@ -294,6 +298,7 @@
     <None Include="Input\knuckles_default.json" />
     <None Include="Input\oculus_touch_default.json" />
     <None Include="Input\vive_controller_default.json" />
+    <None Include="Revive.def" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Revive.rc" />

--- a/Revive/Revive.vcxproj.filters
+++ b/Revive/Revive.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -195,6 +195,9 @@
     </None>
     <None Include="Input\vive_controller_default.json">
       <Filter>Resource Files</Filter>
+    </None>
+    <None Include="Revive.def">
+      <Filter>Source Files</Filter>
     </None>
   </ItemGroup>
   <ItemGroup>

--- a/ReviveInjector/main.cpp
+++ b/ReviveInjector/main.cpp
@@ -239,8 +239,9 @@ int wmain(int argc, wchar_t *argv[]) {
 
 	if (dlls.empty())
 	{
-		dlls.add(moduleDir + std::string("\\openvr_api64.dll"));
+		// Not sure why, but LibRevive must appear first in this list
 		dlls.add(moduleDir + std::string("\\LibRevive64.dll"));
+		dlls.add(moduleDir + std::string("\\openvr_api64.dll"));
 	}
 	
 	LOG("Command for injector is: %ls\n", path);
@@ -264,7 +265,12 @@ int wmain(int argc, wchar_t *argv[]) {
 	if (file)
 		*file = L'\0';
 
-	if (!DetourCreateProcessWithDlls(NULL, path, NULL, NULL, FALSE, 0, NULL, (file && ext) ? workingDir : NULL, &si, &pi, (DWORD)dlls.size(), dlls.c_str(), NULL))
+	// Need to use moduleDir as working directory for DetourCreateProcessWithDlls
+	// to avoid having to copy dlls into game .exe path
+	wchar_t moduleDir_w[MAX_PATH];
+	std::mbstowcs(moduleDir_w, moduleDir, MAX_PATH);
+
+	if (!DetourCreateProcessWithDlls(NULL, path, NULL, NULL, FALSE, 0, NULL, moduleDir_w, &si, &pi, (DWORD)dlls.size(), dlls.c_str(), NULL))
 	{
 		LOG("Failed to create process\n");
 		return -1;


### PR DESCRIPTION
The original switch to Detours didn't correctly implement all of the necessary details. This commit implements the bolded section below. Tested with Condor2. Could likely be cleaned up a little bit (I'm not a C++ guy 😐)

From the Detours Wiki:

> You should use the DetourCreateProcessWithDllEx or DetourCreateProcessWithDlls API to start a process with your DLL. Furthermore, your DLLs must:
> 
> **Export the DetourFinishHelperProcess API as export ordinal 1.**
> 
> Call the DetourIsHelperProcess API in your DllMain function. Immediately return TRUE if DetourIsHelperProcess return TRUE.
> 
> Call the DetourCreateProcessWithDllEx or DetourCreateProcessWithDlls API instead of DetourCreateProcessWithDll to create new target processes.