### PR TITLE
Update README to indicate Index support & match GitHub "About" text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Revive Compatibility Layer
 
-This is a compatibility layer between the Oculus SDK and OpenVR/OpenXR. It allows you to play Oculus-exclusive games on your HTC Vive.
+This is a compatibility layer between the Oculus SDK and OpenVR/OpenXR. It allows you to play Oculus-exclusive games on your HTC Vive or Valve Index.
 
 [Refer to the wiki](https://github.com/LibreVR/Revive/wiki) if you run into any problems. You can also find a [community-compiled list of working games on the wiki](https://github.com/LibreVR/Revive/wiki/Compatibility-list), feel free to add your own results.
 


### PR DESCRIPTION
This GitHub page's "About" section specifies that Revive will allow Oculus games support for both the Vive and Index, but the README only specifies Vive support.

> Play Oculus-exclusive games on the HTC Vive or Valve Index, scroll down for downloads and installation instructions.
^^^ "About" content

This README change will allow the README to reflect the "About" content (and, hopefully, reduce confusion for Index owners, like me).