### PR TITLE
Fix for games using the latest Unity OVRPlugin

### DIFF
--- a/Revive/main.cpp
+++ b/Revive/main.cpp
@@ -8,7 +8,8 @@
 #include "Extras\OVR_CAPI_Util.h"
 #include "OVR_Version.h"
 
-static HMODULE(WINAPI* TrueLoadLibrary)(LPCWSTR lpFileName) = LoadLibraryW;
+static HMODULE(WINAPI* TrueLoadLibraryW)(LPCWSTR lpFileName) = LoadLibraryW;
+static HMODULE(WINAPI* TrueLoadLibraryExW)(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwFlags) = LoadLibraryExW;
 static HANDLE(WINAPI* TrueOpenEvent)(DWORD dwDesiredAccess, BOOL bInheritHandle, LPCWSTR lpName) = OpenEventW;
 static HRESULT(WINAPI* TrueDXGIFactory)(REFIID riid, void **ppFactory) = CreateDXGIFactory;
 
@@ -35,24 +36,40 @@ HANDLE WINAPI HookOpenEvent(DWORD dwDesiredAccess, BOOL bInheritHandle, LPCWSTR 
 	return TrueOpenEvent(dwDesiredAccess, bInheritHandle, lpName);
 }
 
-HMODULE WINAPI HookLoadLibrary(LPCWSTR lpFileName)
+HMODULE WINAPI HookLoadLibraryW(LPCWSTR lpFileName)
 {
 	LPCWSTR name = PathFindFileNameW(lpFileName);
 	LPCWSTR ext = PathFindExtensionW(name);
 	size_t length = ext - name;
 
 	// Load our own library again so the ref count is incremented.
-	if (wcsncmp(name, ovrModuleName, length) == 0)
-		return TrueLoadLibrary(revModuleName);
+	if (wcsncmp(name, ovrModuleName, length) == 0) {
+		return TrueLoadLibraryW(revModuleName);
+	}
+		return TrueLoadLibraryW(lpFileName);
 
-	return TrueLoadLibrary(lpFileName);
+}
+
+HMODULE WINAPI HookLoadLibraryExW(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwFlags)
+{
+	LPCWSTR name = PathFindFileNameW(lpLibFileName);
+	LPCWSTR ext = PathFindExtensionW(name);
+	size_t length = ext - name;
+
+	// Load our own library again so the ref count is incremented.
+	if (wcsncmp(name, ovrModuleName, length) == 0) {
+		return TrueLoadLibraryExW(revModuleName, hFile, dwFlags);
+	}
+	return TrueLoadLibraryExW(lpLibFileName, hFile, dwFlags);
+
 }
 
 void AttachDetours()
 {
 	DetourTransactionBegin();
 	DetourUpdateThread(GetCurrentThread());
-	DetourAttach((PVOID*)&TrueLoadLibrary, HookLoadLibrary);
+	DetourAttach((PVOID*)&TrueLoadLibraryW, HookLoadLibraryW);
+	DetourAttach((PVOID*)&TrueLoadLibraryExW, HookLoadLibraryExW);
 	DetourAttach((PVOID*)&TrueOpenEvent, HookOpenEvent);
 	DetourAttach((PVOID*)&TrueDXGIFactory, HookDXGIFactory);
 	DetourTransactionCommit();
@@ -62,7 +79,8 @@ void DetachDetours()
 {
 	DetourTransactionBegin();
 	DetourUpdateThread(GetCurrentThread());
-	DetourDetach((PVOID*)&TrueLoadLibrary, HookLoadLibrary);
+	DetourDetach((PVOID*)&TrueLoadLibraryW, HookLoadLibraryW);
+	DetourDetach((PVOID*)&TrueLoadLibraryExW, HookLoadLibraryExW);
 	DetourDetach((PVOID*)&TrueOpenEvent, HookOpenEvent);
 	DetourDetach((PVOID*)&TrueDXGIFactory, HookDXGIFactory);
 	DetourTransactionCommit();

--- a/Revive/main.cpp
+++ b/Revive/main.cpp
@@ -43,11 +43,10 @@ HMODULE WINAPI HookLoadLibraryW(LPCWSTR lpFileName)
 	size_t length = ext - name;
 
 	// Load our own library again so the ref count is incremented.
-	if (wcsncmp(name, ovrModuleName, length) == 0) {
+	if (wcsncmp(name, ovrModuleName, length) == 0) 
 		return TrueLoadLibraryW(revModuleName);
-	}
-		return TrueLoadLibraryW(lpFileName);
-
+	
+	return TrueLoadLibraryW(lpFileName);
 }
 
 HMODULE WINAPI HookLoadLibraryExW(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwFlags)
@@ -57,11 +56,10 @@ HMODULE WINAPI HookLoadLibraryExW(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwF
 	size_t length = ext - name;
 
 	// Load our own library again so the ref count is incremented.
-	if (wcsncmp(name, ovrModuleName, length) == 0) {
+	if (wcsncmp(name, ovrModuleName, length) == 0) 
 		return TrueLoadLibraryExW(revModuleName, hFile, dwFlags);
-	}
+	
 	return TrueLoadLibraryExW(lpLibFileName, hFile, dwFlags);
-
 }
 
 void AttachDetours()

--- a/ReviveXR/main.cpp
+++ b/ReviveXR/main.cpp
@@ -9,7 +9,8 @@
 #include "OVR_CAPI.h"
 #include "OVR_Version.h"
 
-static HMODULE(WINAPI* TrueLoadLibrary)(LPCWSTR lpFileName) = LoadLibraryW;
+static HMODULE(WINAPI* TrueLoadLibraryW)(LPCWSTR lpFileName) = LoadLibraryW;
+static HMODULE(WINAPI* TrueLoadLibraryExW)(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwFlags) = LoadLibraryExW;
 static HANDLE(WINAPI* TrueOpenEvent)(DWORD dwDesiredAccess, BOOL bInheritHandle, LPCWSTR lpName) = OpenEventW;
 
 HMODULE revModule;
@@ -25,24 +26,42 @@ HANDLE WINAPI HookOpenEvent(DWORD dwDesiredAccess, BOOL bInheritHandle, LPCWSTR 
 	return TrueOpenEvent(dwDesiredAccess, bInheritHandle, lpName);
 }
 
-HMODULE WINAPI HookLoadLibrary(LPCWSTR lpFileName)
+HMODULE WINAPI HookLoadLibraryW(LPCWSTR lpFileName)
 {
 	LPCWSTR name = PathFindFileNameW(lpFileName);
 	LPCWSTR ext = PathFindExtensionW(name);
 	size_t length = ext - name;
 
 	// Load our own library again so the ref count is incremented.
-	if (wcsncmp(name, ovrModuleName, length) == 0)
-		return TrueLoadLibrary(revModuleName);
+	if (wcsncmp(name, ovrModuleName, length) == 0) {
+		return TrueLoadLibraryW(revModuleName);
+	}
+		return TrueLoadLibraryW(lpFileName);
 
-	return TrueLoadLibrary(lpFileName);
 }
+
+HMODULE WINAPI HookLoadLibraryExW(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwFlags)
+{
+	LPCWSTR name = PathFindFileNameW(lpLibFileName);
+	LPCWSTR ext = PathFindExtensionW(name);
+	size_t length = ext - name;
+
+	// Load our own library again so the ref count is incremented.
+	if (wcsncmp(name, ovrModuleName, length) == 0) {
+		return TrueLoadLibraryExW(revModuleName, hFile, dwFlags);
+	}
+	return TrueLoadLibraryExW(lpLibFileName, hFile, dwFlags);
+
+}
+
+
 
 void AttachDetours()
 {
 	DetourTransactionBegin();
 	DetourUpdateThread(GetCurrentThread());
-	DetourAttach(&(PVOID&)TrueLoadLibrary, HookLoadLibrary);
+	DetourAttach((PVOID*)&TrueLoadLibraryW, HookLoadLibraryW);
+	DetourAttach((PVOID*)&TrueLoadLibraryExW, HookLoadLibraryExW);
 	DetourAttach(&(PVOID&)TrueOpenEvent, HookOpenEvent);
 	DetourTransactionCommit();
 }
@@ -51,7 +70,8 @@ void DetachDetours()
 {
 	DetourTransactionBegin();
 	DetourUpdateThread(GetCurrentThread());
-	DetourDetach(&(PVOID&)TrueLoadLibrary, HookLoadLibrary);
+	DetourDetach((PVOID*)&TrueLoadLibraryW, HookLoadLibraryW);
+	DetourDetach((PVOID*)&TrueLoadLibraryExW, HookLoadLibraryExW);
 	DetourDetach(&(PVOID&)TrueOpenEvent, HookOpenEvent);
 	DetourTransactionCommit();
 }

--- a/ReviveXR/main.cpp
+++ b/ReviveXR/main.cpp
@@ -33,11 +33,10 @@ HMODULE WINAPI HookLoadLibraryW(LPCWSTR lpFileName)
 	size_t length = ext - name;
 
 	// Load our own library again so the ref count is incremented.
-	if (wcsncmp(name, ovrModuleName, length) == 0) {
+	if (wcsncmp(name, ovrModuleName, length) == 0)
 		return TrueLoadLibraryW(revModuleName);
-	}
-		return TrueLoadLibraryW(lpFileName);
-
+	
+	return TrueLoadLibraryW(lpFileName);
 }
 
 HMODULE WINAPI HookLoadLibraryExW(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwFlags)
@@ -47,14 +46,11 @@ HMODULE WINAPI HookLoadLibraryExW(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwF
 	size_t length = ext - name;
 
 	// Load our own library again so the ref count is incremented.
-	if (wcsncmp(name, ovrModuleName, length) == 0) {
+	if (wcsncmp(name, ovrModuleName, length) == 0) 
 		return TrueLoadLibraryExW(revModuleName, hFile, dwFlags);
-	}
+	
 	return TrueLoadLibraryExW(lpLibFileName, hFile, dwFlags);
-
 }
-
-
 
 void AttachDetours()
 {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
 install:
   # update vcpkg to the latest version
   - cd C:\Tools\vcpkg
-  - git pull
+  - git checkout 05e56b2c86c9a9409d0935d0646fc05d8c4e9d30
   - git apply %APPVEYOR_BUILD_FOLDER%\fix-vcpkg-openxr-static-loader.patch
   - .\bootstrap-vcpkg.bat
   - cd %APPVEYOR_BUILD_FOLDER%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,6 @@ install:
   # update vcpkg to the latest version
   - cd C:\Tools\vcpkg
   - git pull
-  - git checkout 05e56b2c86c9a9409d0935d0646fc05d8c4e9d30
-  - git apply %APPVEYOR_BUILD_FOLDER%\fix-vcpkg-openxr-static-loader.patch
   - .\bootstrap-vcpkg.bat
   - cd %APPVEYOR_BUILD_FOLDER%
   - git submodule update --init --recursive

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,8 @@ install:
   # update vcpkg to the latest version
   - cd C:\Tools\vcpkg
   - git pull
+  - git checkout 05e56b2c86c9a9409d0935d0646fc05d8c4e9d30
+  - git apply %APPVEYOR_BUILD_FOLDER%\fix-vcpkg-openxr-static-loader.patch
   - .\bootstrap-vcpkg.bat
   - cd %APPVEYOR_BUILD_FOLDER%
   - git submodule update --init --recursive

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
 install:
   # update vcpkg to the latest version
   - cd C:\Tools\vcpkg
+  - git pull
   - git checkout 05e56b2c86c9a9409d0935d0646fc05d8c4e9d30
   - git apply %APPVEYOR_BUILD_FOLDER%\fix-vcpkg-openxr-static-loader.patch
   - .\bootstrap-vcpkg.bat


### PR DESCRIPTION
The latest Unity OVRPlugin switched from loading LibOVRRT with HookLoadLibraryW to HookLoadLibraryExW.